### PR TITLE
Capture birth times from Linux

### DIFF
--- a/pyaff4/logical.py
+++ b/pyaff4/logical.py
@@ -14,8 +14,8 @@
 
 import os
 import platform
-from pyaff4 import lexicon
-from pyaff4 import rdfvalue
+from pyaff4 import lexicon, rdfvalue
+from pyaff4 import statx
 import time
 import tzlocal
 from datetime import datetime
@@ -54,25 +54,29 @@ class FSMetadata(object):
             return MacOSFSMetadata(filename, filename, size, lastWritten, accessed, recordChanged, birthTime)
         elif p == "Linux":
             size = s.st_size
-            # TODO: birthTime
             lastWritten = datetime.fromtimestamp(s.st_mtime, local_tz)
             accessed = datetime.fromtimestamp(s.st_atime, local_tz)
             recordChanged = datetime.fromtimestamp(s.st_ctime, local_tz)
-            return LinuxFSMetadata(filename, filename, size, lastWritten, accessed, recordChanged)
+
+            sx = statx.statx(filename)
+            birthTime = datetime.fromtimestamp(sx.get_btime(), local_tz)
+            return LinuxFSMetadata(filename, filename, size, lastWritten, accessed, recordChanged, birthTime)
 
 
 class LinuxFSMetadata(FSMetadata):
-    def __init__(self, urn, name, size, lastWritten, lastAccessed, recordChanged):
+    def __init__(self, urn, name, size, lastWritten, lastAccessed, recordChanged, birthTime):
         super(LinuxFSMetadata, self).__init__(urn, name, size)
         self.lastWritten = lastWritten
         self.lastAccessed = lastAccessed
         self.recordChanged = recordChanged
+        self.birthTime = birthTime
 
     def store(self, resolver):
         resolver.Set(self.urn, rdfvalue.URN(lexicon.AFF4_STREAM_SIZE), rdfvalue.XSDInteger(self.length))
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastWritten), rdfvalue.XSDDateTime(self.lastWritten))
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastAccessed), rdfvalue.XSDDateTime(self.lastAccessed))
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.recordChanged), rdfvalue.XSDDateTime(self.recordChanged))
+        resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.birthTime), rdfvalue.XSDDateTime(self.birthTime))
 
 
 class MacOSFSMetadata(FSMetadata):
@@ -103,3 +107,4 @@ class WindowsFSMetadata(FSMetadata):
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastWritten), rdfvalue.XSDDateTime(self.lastWritten))
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastAccessed), rdfvalue.XSDDateTime(self.lastAccessed))
         resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.birthTime), rdfvalue.XSDDateTime(self.birthTime))
+

--- a/pyaff4/statx.py
+++ b/pyaff4/statx.py
@@ -1,0 +1,109 @@
+import os
+import ctypes
+import platform
+
+from pyaff4 import utils
+
+
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/stat.h?h=v4.19#n46
+class StatxTimestamp(ctypes.Structure):
+    _fields_ = [("tv_sec", ctypes.c_longlong),
+                ("tv_nsec", ctypes.c_uint),
+                ("__reserved", ctypes.c_int)]
+
+
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/stat.h?h=v4.19#n62
+class Statx(ctypes.Structure):
+    _fields_ = [("stx_mask", ctypes.c_uint),
+                ("stx_blksize", ctypes.c_uint),
+                ("stx_attributes", ctypes.c_ulonglong),
+
+                ("stx_nlink", ctypes.c_uint),
+                ("stx_uid", ctypes.c_uint),
+                ("stx_gid", ctypes.c_uint),
+                ("stx_mode", ctypes.c_ushort),
+                ("__spare0", ctypes.c_ushort * 1),
+
+                ("stx_ino", ctypes.c_ulonglong),
+                ("stx_size", ctypes.c_ulonglong),
+                ("stx_blocks", ctypes.c_ulonglong),
+                ("stx_attributes_mask", ctypes.c_ulonglong),
+
+                ("stx_atime", StatxTimestamp),
+                ("stx_btime", StatxTimestamp),
+                ("stx_ctime", StatxTimestamp),
+                ("stx_mtime", StatxTimestamp),
+
+                ("stx_rdev_major", ctypes.c_uint),
+                ("stx_rdev_minor", ctypes.c_uint),
+                ("stx_dev_major", ctypes.c_uint),
+                ("stx_dev_minor", ctypes.c_uint),
+
+                ("__spare2", ctypes.c_ulonglong * 14)]
+
+    def get_btime(self):
+        return self.stx_btime.tv_sec + (self.stx_btime.tv_nsec / 1000000000)
+
+
+# https://github.com/hrw/syscalls-table
+SYSCALLS = {
+    "alpha": 522,
+    "arc": 291,
+    "arm": 397,
+    "arm64": 291,
+    "armoabi": 9437581,
+    "c6x": 291,
+    "csky": 291,
+    "h8300": 291,
+    "hexagon": 291,
+    "i386": 383,
+    "m68k": 379,
+    "metag": 291,
+    "microblaze": 398,
+    "mips64": 5326,
+    "mips64n32": 6330,
+    "mipso32": 4366,
+    "nds32": 291,
+    "nios2": 291,
+    "openrisc": 291,
+    "parisc": 349,
+    "powerpc": 383,
+    "powerpc64": 383,
+    "riscv": 291,
+    "s390": 379,
+    "s390x": 379,
+    "score": 291,
+    "sparc": 360,
+    "sparc64": 360,
+    "tile": 291,
+    "tile64": 291,
+    "unicore32": 291,
+    "x32": 1073742156,
+    "x86_64": 332,
+    "xtensa": 351,
+}
+
+
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fcntl.h?h=v4.19
+AT_FDCWD = -100 # fcntl.h
+AT_SYMLINK_NOFOLLOW = 0x100 # fcntl.h
+STATX_ALL = 0xfff # stat.h
+SYS_STATX = SYSCALLS[platform.machine()]
+
+
+def statx(path):
+    pathname = ctypes.c_char_p(utils.SmartStr(path))
+    statxbuf = ctypes.create_string_buffer(ctypes.sizeof(Statx))
+
+    lib = ctypes.CDLL(None, use_errno=True)
+    syscall = lib.syscall
+
+    # int statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf);
+    syscall.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_uint, ctypes.c_char_p]
+    syscall.restype = ctypes.c_int
+
+    if syscall(SYS_STATX, AT_FDCWD, pathname, AT_SYMLINK_NOFOLLOW, STATX_ALL, statxbuf):
+        e = ctypes.get_errno()
+        raise OSError(e, os.strerror(e), path)
+    return Statx.from_buffer(statxbuf)
+

--- a/pyaff4/statx.py
+++ b/pyaff4/statx.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import os
 import ctypes
 import platform


### PR DESCRIPTION
Capture birth times when performing logical collections from Linux. Because there is no Glibc interface, I've included the statx syscall numbers for several platforms.