### PR TITLE
Removed unused incorrect import statement blocking Python 3 from working

### DIFF
--- a/pyaff4/aff4_metadata.py
+++ b/pyaff4/aff4_metadata.py
@@ -1,5 +1,3 @@
-import aff4
-
 class RDFObject(object):
     def __init__(self, URN, resolver, lexicon):
         self.resolver = resolver


### PR DESCRIPTION
Currently, when trying to import parts of pyaff4 0.27 in Python 3, via something like
`from pyaff4 import aff4_metadata ` or `from pyaff4 import rdfvalue` causes a ModuleNotFound error.

This fixes the issue by simply removing the unused (and incorrectly named) import.