### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.egg-info/
 dist/
 /.idea/
+/build/
 
 *~

--- a/aff4.py
+++ b/aff4.py
@@ -292,7 +292,7 @@ def extractAll(container_name, destFolder):
     urn = None
 
     with container.Container.openURNtoContainer(container_urn) as volume:
-        printVolumeInfo(file, volume)
+        printVolumeInfo(container_urn.original_filename, volume)
         resolver = volume.resolver
         for imageUrn in resolver.QueryPredicateObject(volume.urn, lexicon.AFF4_TYPE, lexicon.standard11.FileImage):
             imageUrn = utils.SmartUnicode(imageUrn)

--- a/aff4.py
+++ b/aff4.py
@@ -328,7 +328,7 @@ def extract(container_name, imageURNs, destFolder):
         urn = None
 
         with container.Container.openURNtoContainer(container_urn) as volume:
-            printVolumeInfo(file, volume)
+            printVolumeInfo(container_urn.original_filename, volume)
             resolver = volume.resolver
             for imageUrn in imageURNs:
                 imageUrn = utils.SmartUnicode(imageUrn)
@@ -347,7 +347,7 @@ def extract(container_name, imageURNs, destFolder):
                             except OSError as exc:  # Guard against race condition
                                 if exc.errno != errno.EEXIST:
                                     raise
-                        with open(destFile, "w") as destStream:
+                        with open(destFile, "wb") as destStream:
                             shutil.copyfileobj(srcStream, destStream, length=32*2014)
                             print ("\tExtracted %s to %s" % (pathName, destFile))
                     else:

--- a/pyaff4/container.py
+++ b/pyaff4/container.py
@@ -262,7 +262,7 @@ class LogicalImageContainer(Container):
 
     def open(self, urn):
         pathName = next(self.resolver.QuerySubjectPredicate(self.urn, urn, lexicon.standard11.pathName))
-        return aff4.LogicalImage(self.resolver, self.urn, urn, pathName)
+        return aff4.LogicalImage(self, self.resolver, self.urn, urn, pathName)
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Return ourselves to the resolver cache.
@@ -277,11 +277,11 @@ class PreStdLogicalImageContainer(LogicalImageContainer):
         _images = self.resolver.QueryPredicateObject(self.urn, lexicon.AFF4_TYPE, lexicon.standard.Image)
         for image in _images:
             pathName = next(self.resolver.QuerySubjectPredicate(self.urn, image, self.lexicon.pathName))
-            yield aff4.LogicalImage(self.resolver, self.urn, image, pathName)
+            yield aff4.LogicalImage(self, self.resolver, self.urn, image, pathName)
 
     def open(self, urn):
         pathName = next(self.resolver.QuerySubjectPredicate(self.urn, urn, self.lexicon.pathName))
-        return aff4.LogicalImage(self.resolver, self.urn, urn, pathName)
+        return aff4.LogicalImage(self, self.resolver, self.urn, urn, pathName)
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Return ourselves to the resolver cache.


### PR DESCRIPTION
This pull request fixes two issues:

#11: `aff4.LogicalImage.__init__()` requires the container as first parameter. However, several functions in container.py (in `LogicalImageContainer.images()`, `PreStdLogicalImageContainer.images()` and `PreStdLogicalImageContainer.open()`) were missing that parameter (`self`), producing an exception when invoked as missing a positional argument.

#12: `aff4.extract()` and `aff4.extractAll()` functions were calling `aff4.printVolumeInfo()` passing the undefined variable `file`. Fixed passing the original file name of the container.