### PR TITLE
Make call to extractAll() function behave as call to extract()

### DIFF
--- a/aff4.py
+++ b/aff4.py
@@ -411,7 +411,7 @@ def main(argv):
         extract(dest, args.srcFiles, args.folder)
     elif args.extract_all == True:
         dest = args.aff4container
-        extractAll(dest, args.srcFiles[0])
+        extractAll(dest, args.folder)
     elif args.ingest == True:
         dest = args.aff4container
         ingestZipfile(dest, args.srcFiles, False, args.paranoid)


### PR DESCRIPTION
The call to the `extractAll` function seems to make a semantically
incorrect usage of `args.srcFiles[0]`.  The `extract` function uses
`arg.folder` as an output specifier, and `args.srcFiles` as an input
specifier.  `extractAll` should drop input parameters.

This patch modifies the `extractAll` call to use `args.folder` to
specify output.  However, this may cause backwards-incompatible changes
with any scripts that use `--extract-all`, so this should wait for the
next major version (keeping with SemVer called for in Issue 8).
https://github.com/aff4/pyaff4/issues/8

This patch is independent of Pull Request 14.
https://github.com/aff4/pyaff4/pull/14

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>