### PR TITLE
Fixed error when trying to add folders on windows 

### DIFF
--- a/pyaff4/logical.py
+++ b/pyaff4/logical.py
@@ -127,10 +127,10 @@ class WindowsFSMetadata(FSMetadata):
         self.birthTime = birthTime
 
     def store(self, resolver):
-        resolver.Set(self.urn, rdfvalue.URN(lexicon.AFF4_STREAM_SIZE), rdfvalue.XSDInteger(self.length))
-        resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastWritten), rdfvalue.XSDDateTime(self.lastWritten))
-        resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.lastAccessed), rdfvalue.XSDDateTime(self.lastAccessed))
-        resolver.Set(self.urn, rdfvalue.URN(lexicon.standard11.birthTime), rdfvalue.XSDDateTime(self.birthTime))
+        resolver.Set(self.urn, self.urn, rdfvalue.URN(lexicon.AFF4_STREAM_SIZE), rdfvalue.XSDInteger(self.length))
+        resolver.Set(self.urn, self.urn, rdfvalue.URN(lexicon.standard11.lastWritten), rdfvalue.XSDDateTime(self.lastWritten))
+        resolver.Set(self.urn, self.urn,rdfvalue.URN(lexicon.standard11.lastAccessed), rdfvalue.XSDDateTime(self.lastAccessed))
+        resolver.Set(self.urn, self.urn, rdfvalue.URN(lexicon.standard11.birthTime), rdfvalue.XSDDateTime(self.birthTime))
 
 def resetTimestampsPosix(destFile, lastWritten, lastAccessed, recordChanged, birthTime):
     if lastWritten == None or lastAccessed == None:


### PR DESCRIPTION
- missing argument in logical.py which caused program to error out on Windows (Tested on Win7 and Win10) with the following code

Traceback (most recent call last):
  File "aff4.py", line 421, in <module>
    main(sys.argv)
  File "aff4.py", line 399, in main
    addPathNames(dest, args.srcFiles, args.recursive, args.append, args.hash)
  File "aff4.py", line 263, in addPathNames
    fsmeta.store(resolver)
  File "C:\Users\Mikolaj\Desktop\aff4\pyaff4\pyaff4\logical.py", line 130, in st
ore
    resolver.Set(self.urn, rdfvalue.URN(lexicon.AFF4_STREAM_SIZE), rdfvalue.XSDI
nteger(self.length))
TypeError: Set() missing 1 required positional argument: 'value'

Fixed it by mirroring ClassicUnixMetadata.store()
