### PR TITLE
Fix dependencies, +pycryptodomex, -hexdump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ tzlocal == 1.5.1
 html5lib == 1.0.1
 python-dateutil == 2.8.0
 fastchunking == 0.0.3
-hexdump
 pynacl
 pycryptodome
+pycryptodomex
 pycryptoplus
 aes-keywrap
 passlib

--- a/samples/simple_block_read.py
+++ b/samples/simple_block_read.py
@@ -15,7 +15,7 @@
 from pyaff4 import container
 import binascii
 import os
-import hexdump
+from pyaff4 import hexdump
 
 referenceImagesPath = os.path.join(os.path.dirname(__file__), u"..", u"test_images")
 stdLinear = os.path.join(referenceImagesPath, u"AFF4Std", u"Base-Linear.aff4")


### PR DESCRIPTION
Changed dependencies to fix compile issues. Installing `pycryptodomex` fixes this error:
`File "c:\Python37-32\lib\site-packages\pyaff4\aes_keywrap.py", line 8, in <module>`  
`    from Cryptodome.Cipher import AES  `
`ModuleNotFoundError: No module named 'Cryptodome'`

Alternatively, one could change the code to 
`    from Crypto.Cipher import AES  `
and that would work too..

Also, changed the example to use the included hexdump.py, thus eliminating need for installing `hexdump`. Everywhere else in the code, only that one is used.

This was tested/used on python 3.7 on windows.