### PR TITLE
Handle filenames containing quotation marks

### DIFF
--- a/pyaff4/escaping.py
+++ b/pyaff4/escaping.py
@@ -62,6 +62,8 @@ def arnPathFragment_from_path(pathName):
             escaped_path.append("/")
         elif c == ' ':
             escaped_path.append("%20")
+        elif c == '"':
+            escaped_path.append("%22")
         elif c == '%':
             escaped_path.append("%25")
         elif c in FORBIDDEN:


### PR DESCRIPTION
Should we use urllib.request.pathname2url instead?