### PR TITLE
Add uncompressed chunk padding

### DIFF
--- a/pyaff4/aff4_image.py
+++ b/pyaff4/aff4_image.py
@@ -82,6 +82,11 @@ class _CompressorStream(object):
             self.bevy_length += compressedLen
             return compressed_chunk
         else:
+            # On final chunks that aren't compressed, pad if they are less than chunk_size
+            # so that at decompression we won't try to decompress an already decompressed chunk.
+            if chunkLen < self.owner.chunk_size:
+                padding = self.owner.chunk_size - chunkLen
+                chunk += b"\x00" * padding
             self.bevy_index.append((self.bevy_length, self.owner.chunk_size))
             self.bevy_length += self.owner.chunk_size
             return chunk


### PR DESCRIPTION
On a strange edge case, the final chunk of a file can be larger than `chunk_size` when compressed and smaller than `chunk_size` when uncompressed. If the compressed chunk is larger than `chunk_size`, the uncompressed chunk is used. However, since the uncompressed final chunk is smaller than `chunk_size`, when extracting, `pyaff4` attempts to decompress the uncompressed chunk leading to a `snappy.UncompressError` error. Adding a check and padding any uncompressed chunk less than `chunk_size` allows for proper extraction of the files from the container and no errors. This was found when a single file out of 34,274 files created this error.  