### PR TITLE
Critical: Fixes ZipFileHeader Struct and Zip64 Header creation - Implements switch to enable creation of large sized ZipSegments and ZIP_STORED containers

### DIFF
--- a/pyaff4/aff4_image.py
+++ b/pyaff4/aff4_image.py
@@ -502,7 +502,6 @@ class AFF4Image(aff4.AFF4Stream):
             print(corrected_urn)
             bevy_urn = rdfvalue.URN().UnSerializeFromString(corrected_urn)
             # bevy_index_urn = rdfvalue.URN("%s.index" % bevy_urn) # This is unused anyway apparently
-            print("AXIOOOOOM")
         else:
             bevy_urn = self.urn.Append("%08d" % bevy_id)
             bevy_index_urn = rdfvalue.URN("%s.index" % bevy_urn)

--- a/pyaff4/aff4_image.py
+++ b/pyaff4/aff4_image.py
@@ -15,6 +15,7 @@
 """This module implements the standard AFF4 Image."""
 from __future__ import division
 from __future__ import unicode_literals
+
 from builtins import range
 from builtins import str
 from past.utils import old_div
@@ -23,6 +24,7 @@ import binascii
 import logging
 import lz4.block
 import struct
+import urllib
 
 from expiringdict import ExpiringDict
 
@@ -491,8 +493,19 @@ class AFF4Image(aff4.AFF4Stream):
             return result
 
     def reloadBevy(self, bevy_id):
-        bevy_urn = self.urn.Append("%08d" % bevy_id)
-        bevy_index_urn = rdfvalue.URN("%s.index" % bevy_urn)
+        if "AXIOMProcess" in self.version.tool:
+            # Axiom does strange stuff with paths and URNs, we need to fix the URN for reading bevys
+            volume_urn = '/'.join(self.urn.SerializeToString().split('/')[0:3])
+            original_filename = self.resolver.Get(volume_urn, self.urn, rdfvalue.URN(lexicon.standard11.pathName))[0]
+            original_filename_escaped = urllib.parse.quote(str(original_filename).encode(), safe='/\\')
+            corrected_urn = f"{volume_urn}/{original_filename_escaped}\\{'%08d' % bevy_id}".encode()
+            print(corrected_urn)
+            bevy_urn = rdfvalue.URN().UnSerializeFromString(corrected_urn)
+            # bevy_index_urn = rdfvalue.URN("%s.index" % bevy_urn) # This is unused anyway apparently
+            print("AXIOOOOOM")
+        else:
+            bevy_urn = self.urn.Append("%08d" % bevy_id)
+            bevy_index_urn = rdfvalue.URN("%s.index" % bevy_urn)
         if LOGGER.isEnabledFor(logging.INFO):
             LOGGER.info("Reload Bevy %s", bevy_urn)
         chunks = []

--- a/pyaff4/container.py
+++ b/pyaff4/container.py
@@ -362,14 +362,14 @@ class WritableLogicalImageContainer(Container):
             stream.WriteStream(readstream)
 
         # write the logical stream as a zip segment using the Stream API
-    def writeZipStream(self, image_urn, filename, readstream):
+    def writeZipStream(self, image_urn, filename, readstream, progress=None):
         with self.resolver.AFF4FactoryOpen(self.urn) as volume:
             with volume.CreateMember(image_urn) as streamed:
                 if self.compression_method is not None and self.compression_method == lexicon.AFF4_IMAGE_COMPRESSION_STORED:
                     streamed.compression_method = zip.ZIP_STORED
                 else:
                     streamed.compression_method = zip.ZIP_DEFLATE
-                streamed.WriteStream(readstream)
+                streamed.WriteStream(readstream, progress=progress)
 
     # create a file like object for writing a logical image as a new compressed block stream
     def newCompressedBlockStream(self, image_urn, filename):
@@ -404,7 +404,7 @@ class WritableLogicalImageContainer(Container):
         self.resolver.Add(self.urn, image_urn, rdfvalue.URN(lexicon.standard11.pathName), rdfvalue.XSDString(filename))
         return writer
 
-    def writeLogicalStream(self, filename, readstream, length, allow_large_zipsegments=False):
+    def writeLogicalStream(self, filename, readstream, length, allow_large_zipsegments=False, progress=None):
         image_urn = None
         if self.isAFF4Collision(filename):
             image_urn = rdfvalue.URN("aff4://%s" % uuid.uuid4())
@@ -416,7 +416,7 @@ class WritableLogicalImageContainer(Container):
             self.resolver.Add(self.urn, image_urn, rdfvalue.URN(lexicon.AFF4_TYPE),
                               rdfvalue.URN(lexicon.AFF4_IMAGE_TYPE))
         else:
-            self.writeZipStream(image_urn, filename, readstream)
+            self.writeZipStream(image_urn, filename, readstream, progress=progress)
             self.resolver.Add(self.urn, image_urn, rdfvalue.URN(lexicon.AFF4_TYPE), rdfvalue.URN(lexicon.AFF4_ZIP_SEGMENT_IMAGE_TYPE))
 
         self.resolver.Add(self.urn, image_urn, rdfvalue.URN(lexicon.AFF4_TYPE), rdfvalue.URN(lexicon.standard11.FileImage))

--- a/pyaff4/data_store.py
+++ b/pyaff4/data_store.py
@@ -535,6 +535,11 @@ class MemoryDataStore(object):
 
         return result
 
+    def loadZipURN(self, zip):
+        with zip.OpenZipSegment("container.description") as fd:
+            urn = streams.ReadAll(fd).strip(b'\n')
+            return urn
+
     def loadMetadata(self, zip):
         # Load the turtle metadata.
         #if zip.urn not in self.loadedVolumes:

--- a/pyaff4/zip.py
+++ b/pyaff4/zip.py
@@ -132,8 +132,8 @@ class ZipFileHeader(struct_parser.CreateStruct(
         uint16_t lastmodtime;
         uint16_t lastmoddate;
         uint32_t crc32;
-        int32_t compress_size;
-        int32_t file_size;
+        uint32_t compress_size;
+        uint32_t file_size;
         uint16_t file_name_length;
         uint16_t extra_field_len = 0;
         """)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ future == 0.17.1
 aff4-snappy == 0.5.1
 rdflib[sparql] == 4.2.2
 intervaltree == 2.1.0
-pyyaml == 5.4
+pyyaml == 5.10
 tzlocal == 2.1
 html5lib == 1.0.1
 python-dateutil == 2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyyaml
 tzlocal == 2.1
 html5lib == 1.0.1
 python-dateutil == 2.8.0
+pybindgen
 fastchunking == 0.0.3
 hexdump
 pynacl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-future == 0.17.1
+future == 1.0.0
 aff4-snappy @ git+https://github.com/aff4/aff4-snappy@88aba3a3fe4b3f9c20bcfeb5b4c1935c801760bb  # Use source version of aff4-snappy to be able to build on ARM64 (https://github.com/aff4/aff4-snappy/pull/2)
 rdflib[sparql] == 4.2.2
 intervaltree

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ future == 0.17.1
 aff4-snappy == 0.5.1
 rdflib[sparql] == 4.2.2
 intervaltree == 2.1.0
-pyyaml == 5.1
+pyyaml == 5.4
 tzlocal == 2.1
 html5lib == 1.0.1
 python-dateutil == 2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ future == 0.17.1
 aff4-snappy == 0.5.1
 rdflib[sparql] == 4.2.2
 intervaltree == 2.1.0
-pyyaml == 5.10
+pyyaml
 tzlocal == 2.1
 html5lib == 1.0.1
 python-dateutil == 2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 future == 0.17.1
 aff4-snappy == 0.5.1
 rdflib[sparql] == 4.2.2
-intervaltree == 2.1.0
+intervaltree
 pyyaml
 tzlocal == 2.1
 html5lib == 1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future == 0.17.1
-aff4-snappy == 0.5.1
+aff4-snappy @ git+https://github.com/aff4/aff4-snappy@88aba3a3fe4b3f9c20bcfeb5b4c1935c801760bb  # Use source version of aff4-snappy to be able to build on ARM64 (https://github.com/aff4/aff4-snappy/pull/2)
 rdflib[sparql] == 4.2.2
 intervaltree
 pyyaml


### PR DESCRIPTION
As per title, fixes the ZipFileHeader Struct, by changing file_size and compress_size to uint32. Else packing struct fails when file size is > 2GB.

Also introduces an optional switch to enable creation of zip based containers with arbitrary file sizes. This allows creation of containers fully compatible with archive management tools for decompression if needed, as well as ability to import the container as ZIP file in any forensic tool that might not support AFF4-L directly.
Default behaviour is left untouched.